### PR TITLE
feat: Allow Ollama model to be configured via environment variable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=compute,utility
       - OLLAMA_HOST=http://host.docker.internal:11434  # ホストのOllamaを使用
+      - OLLAMA_MODEL=gpt-oss-20b  # 追加
       - JUPYTER_TOKEN=research2025  # Jupyterのトークン（変更推奨）
       - PYTHONPATH=/workspace
       - TZ=Asia/Tokyo

--- a/dockerfile
+++ b/dockerfile
@@ -78,7 +78,7 @@ RUN mkdir -p /root/.claude-bridge && \
 {
   "ollama": {
     "baseUrl": "http://host.docker.internal:11434",
-    "model": "qwen2.5-coder:7b-instruct",
+    "model": "__OLLAMA_MODEL_PLACEHOLDER__",
     "timeout": 300000
   },
   "server": {
@@ -164,6 +164,8 @@ fi
 
 # Claude-bridgeの起動
 echo "🌉 Claude-bridgeを起動中..."
+# モデル設定を環境変数から反映
+sed -i "s|__OLLAMA_MODEL_PLACEHOLDER__|${OLLAMA_MODEL:-qwen2.5-coder:7b-instruct}|g" /root/.claude-bridge/config.json
 cd /opt/claude-bridge
 source .venv/bin/activate
 python -m llm_bridge_claude_code &


### PR DESCRIPTION
This change allows the Ollama model used by claude-bridge to be configured dynamically at runtime.

- Adds `OLLAMA_MODEL` to `docker-compose.yml`.
- Modifies the Dockerfile to generate the claude-bridge config file during container startup, using the `OLLAMA_MODEL` environment variable.
- A default model (`qwen2.5-coder:7b-instruct`) is used if the environment variable is not set.

This makes it possible to change the model without rebuilding the Docker image, which is useful for testing different models or deploying in different environments.