### PR TITLE
Fix: Resolve environment and claude-bridge startup issues

### DIFF
--- a/start-environment.sh
+++ b/start-environment.sh
@@ -38,9 +38,8 @@ echo "   モデル: ${OLLAMA_MODEL:-gpt-oss:20b}"
 echo "   API Base: ${OLLAMA_API_BASE:-http://host.docker.internal:11434/v1}"
 
 # Claude-bridgeを起動（バックグラウンド）
-OPENAI_API_KEY=dummy claude-bridge openai ${OLLAMA_MODEL:-gpt-oss:20b} \
+PORT=${CLAUDE_BRIDGE_PORT:-8080} OPENAI_API_KEY=dummy claude-bridge openai ${OLLAMA_MODEL:-gpt-oss:20b} \
     --baseURL ${OLLAMA_API_BASE:-http://host.docker.internal:11434/v1} \
-    --port ${CLAUDE_BRIDGE_PORT:-8080} \
     > /workspace/logs/claude-bridge.log 2>&1 &
 BRIDGE_PID=$!
 echo "✅ Claude-bridge起動 (PID: $BRIDGE_PID)"


### PR DESCRIPTION
This commit addresses two separate problems in the environment setup:

1.  **NumPy Version Conflict:** The environment was failing with a numpy version incompatibility error (`AttributeError: _ARRAY_API not found`). This was caused by `rdkit` and other packages being incompatible with numpy 2.x.
    - The `Dockerfile` is updated to pin `numpy` to version `1.26.4`.
    - All `pip install` commands are consolidated into a single `RUN` layer to improve dependency resolution and Docker image structure.

2.  **Claude-bridge Startup Error:** The `claude-bridge` service was failing to start due to an `unknown option '--port'` error. The command-line interface for the tool has changed.
    - The `start-environment.sh` script is updated to set the port using the `PORT` environment variable instead of the `--port` flag.