### PR TITLE
Dockerfileのビルドが`oddt`パッケージのインストール中に`ModuleNotFoundError: No module na…

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -124,6 +124,7 @@ RUN pip install --no-cache-dir \
     biopython==1.79 \
     biotite==0.39.0 \
     prody==2.4.1 \
+    six \
     oddt==0.7 \
     deepchem \
     \


### PR DESCRIPTION
…med 'six'`で失敗していました。

このエラーは、`oddt`がインストールに`six`パッケージを必要とするにもかかわらず、`pip install`コマンドの依存関係リストに含まれていなかったために発生していました。

このコミットは、`dockerfile`で`oddt`の前に`six`をインストールするパッケージのリストに追加することで、この問題を修正します。