### PR TITLE
このコミットは、繰り返し発生していたDockerのビルド失敗を解決します。

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -74,8 +74,10 @@ RUN pip install --no-cache-dir --pre \
 
 # ===================================================
 # Pythonパッケージ一括インストール
-# 依存関係の競合を避けるため、一つのRUN命令にまとめる
+# 依存関係の問題を回避するため、sixを先にインストール
 # ===================================================
+RUN pip install --no-cache-dir six
+
 RUN pip install --no-cache-dir \
     # CuPy for CUDA 12.x（GPU4PySCF用）
     cupy-cuda12x==13.6.0 \
@@ -124,7 +126,6 @@ RUN pip install --no-cache-dir \
     biopython==1.79 \
     biotite==0.39.0 \
     prody==2.4.1 \
-    six \
     oddt==0.7 \
     deepchem \
     \


### PR DESCRIPTION
ビルドは`oddt`パッケージのインストール中に`ModuleNotFoundError: No module named 'six'`で失敗していました。これは、`pip`が`oddt`をソースからビルドするために隔離された環境を作成する際に、同じ`pip install`コマンドに含まれていても`six`の依存関係がその環境にインストールされていなかったために発生していました。

このコミットは、`dockerfile`内で`six`を先行する個別の`RUN`コマンドでインストールすることで問題を修正します。これにより、`pip`が`oddt`をビルドしようとする前に`six`がベースイメージレイヤーに確実に存在し、ビルドプロセスで利用可能になります。

また、このコミットは`docker-compose.yml`への変更も維持し、リクエスト通り`gpu-check`サービスが`ubuntu22.04`イメージを使用することを保証します。