### PR TITLE
このコミットは、繰り返し発生していたDockerのビルド失敗を解決し、正しいUbuntuバージョンが使用されるようにします。

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -78,7 +78,7 @@ RUN pip install --no-cache-dir --pre \
 # ===================================================
 RUN pip install --no-cache-dir six
 
-RUN pip install --no-cache-dir \
+RUN pip install --no-cache-dir --no-build-isolation \
     # CuPy for CUDA 12.x（GPU4PySCF用）
     cupy-cuda12x==13.6.0 \
     cutensor-cu12 \


### PR DESCRIPTION
ビルドは`oddt`パッケージのインストール中に`ModuleNotFoundError: No module named 'six'`で失敗していました。これは、先行ステップでインストールされていたにもかかわらず、pipの隔離されたビルド環境に`six`の依存関係が含まれていなかったことが原因でした。

このコミットは、メインの`pip install`コマンドに`--no-build-isolation`フラグを追加することで問題を修正します。これにより、pipはビルドにメイン環境を使用するようになり、そこでは`six`がすでに利用可能です。この依存関係が満たされることを保証するために、`six`をインストールする個別の`RUN`コマンドは維持されます。

また、このコミットは`docker-compose.yml`への変更も維持し、リクエスト通り`gpu-check`サービスが`ubuntu22.04`イメージを使用することを保証します。