### PR TITLE
feat: `claude-bridge` を `codex-cli` に置き換え

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # ================================================
 # RTX 50シリーズ（5090/5070 Ti等）対応版
 # CUDA 12.8 + PyTorch Nightly使用
-# OpenAI API互換モードでclaude-bridge使用
+# Codex CLI と Ollama を連携
 # ================================================
 
 services:
@@ -24,7 +24,7 @@ services:
               count: all
               capabilities: [gpu]
     
-    # 環境変数（RTX 50シリーズ最適化 + OpenAI互換モード）
+    # 環境変数（RTX 50シリーズ最適化 + Ollama連携）
     environment:
       # GPU設定
       - NVIDIA_VISIBLE_DEVICES=all
@@ -34,15 +34,14 @@ services:
       - CUDA_LAUNCH_BLOCKING=0  # パフォーマンス最適化
       - PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True
       
-      # Ollama設定（OpenAI互換エンドポイント）
+      # Ollama設定
       - OLLAMA_HOST=http://host.docker.internal:11434
       - OLLAMA_API_BASE=http://host.docker.internal:11434/v1
       - OLLAMA_MODEL=gpt-oss:20b
-      - OPENAI_API_KEY=dummy  # ダミーキー（Ollamaには不要だが、claude-bridgeが要求）
+      - OPENAI_API_KEY=dummy  # Codexが要求する場合があるため残す
       
       # サービス設定
       - JUPYTER_TOKEN=research2025  # 変更推奨
-      - CLAUDE_BRIDGE_PORT=8080
       - MCP_SERVER_PORT=9121
       
       # Python設定
@@ -57,7 +56,6 @@ services:
     
     # ポートマッピング
     ports:
-      - "8080:8080"    # Claude-bridge
       - "8888:8888"    # JupyterLab
       - "9121:9121"    # Serena-MCP SSE
       - "9122:9122"    # Serena Dashboard
@@ -68,9 +66,8 @@ services:
       - ./workspace:/workspace
       
       # 設定ファイル（永続化）
-      - ./config/claude:/root/.claude
+      - ./config/codex:/root/.codex
       - ./config/serena:/root/.serena
-      - ./config/claude-bridge:/root/.claude-bridge
       
       # データセット用
       - ./datasets:/datasets

--- a/start-environment.sh
+++ b/start-environment.sh
@@ -32,27 +32,8 @@ else
     echo "    2. ollama pull ${OLLAMA_MODEL:-gpt-oss:20b}"
 fi
 
-# Claude-bridgeの起動（OpenAI互換モード）
-echo "🌉 Claude-bridge（OpenAI互換モード）を起動中..."
-echo "   モデル: ${OLLAMA_MODEL:-gpt-oss:20b}"
-echo "   API Base: ${OLLAMA_API_BASE:-http://host.docker.internal:11434/v1}"
-
-# Claude-bridgeを起動（バックグラウンド）
-export CLAUDE_BRIDGE_MODEL="${OLLAMA_MODEL:-gpt-oss:20b}"
-export CLAUDE_BRIDGE_API_BASE="${OLLAMA_API_BASE:-http://host.docker.internal:11434/v1}"
-PORT=${CLAUDE_BRIDGE_PORT:-8080} OPENAI_API_KEY=dummy claude-bridge openai gpt-4-turbo \
-    > /workspace/logs/claude-bridge.log 2>&1 &
-BRIDGE_PID=$!
-echo "✅ Claude-bridge起動 (PID: $BRIDGE_PID)"
-
-# 起動確認（3秒待機）
-sleep 3
-if kill -0 $BRIDGE_PID 2>/dev/null; then
-    echo "✅ Claude-bridgeが正常に起動しました"
-else
-    echo "⚠️  Claude-bridgeの起動に失敗しました。ログを確認してください:"
-    echo "    docker exec comp-chem-ml-env cat /workspace/logs/claude-bridge.log"
-fi
+# Codex CLI はユーザーがフォアグラウンドで実行するため、ここでは何も起動しません。
+# 設定は /root/.codex/config.toml で管理されます。
 
 # Serena-MCPの起動（エラーを無視）
 echo "🎯 Serena-MCPサーバーを起動中..."
@@ -78,14 +59,14 @@ echo ""
 echo "📌 アクセス情報:"
 echo "  - JupyterLab: http://localhost:8888"
 echo "  - Token: ${JUPYTER_TOKEN:-research2025}"
-echo "  - Claude-bridge: http://localhost:8080"
+echo "  - Serena Dashboard: http://localhost:9122"
 echo ""
 echo "🎮 RTX 50シリーズ (sm_120) サポート有効"
 echo "🔧 CUDA 12.8 + PyTorch Nightly"
 echo "🤖 Ollamaモデル: ${OLLAMA_MODEL:-gpt-oss:20b}"
 echo ""
-echo "💡 Claude Codeを使用するには:"
-echo "  docker exec -it comp-chem-ml-env claude"
+echo "💡 Codex CLI を使用するには:"
+echo "  docker exec -it comp-chem-ml-env codex"
 echo ""
 echo "📁 作業ディレクトリ: /workspace"
 echo "📝 ログディレクトリ: /workspace/logs"


### PR DESCRIPTION
`claude-bridge` と `claude-code` を利用したOllama連携で発生していた起動時エラーを解決するため、`@openai/codex` (Codex CLI) を利用する方式に切り替えます。

この変更には以下が含まれます:

- **Dockerfileの更新:**
  - `claude-code` と `claude-bridge` のnpmパッケージインストールを削除。
  - `ollama-mcp-bridge` のgit cloneとビルド処理を削除。
  - `@openai/codex` のnpmパッケージインストールを追加。
  - `claude`用のJSON設定ファイル作成ロジックを削除し、`codex`用のTOML設定ファイル (`/root/.codex/config.toml`) を作成するロジックを追加。OllamaとSerena-MCPへの接続設定を記述。

- **docker-compose.ymlの更新:**
  - `claude-bridge`用のポートマッピング (`8080:8080`) と環境変数を削除。
  - 不要になった設定ボリュームを削除し、`claude`用設定パスを`codex`用に更新。

- **start-environment.shの更新:**
  - `claude-bridge`の起動スクリプトを削除。
  - ユーザーへの案内メッセージを `claude` から `codex` に変更。