### PR TITLE
feat: `claude-bridge` を `codex-cli` に置き換え

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -149,7 +149,7 @@ RUN pip install --no-cache-dir --no-build-isolation \
     git+https://github.com/oraios/serena.git
 
 # Node.js最新化とCodex CLIのインストール
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+RUN curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
     apt-get install -y nodejs && \
     npm install -g npm@latest
 


### PR DESCRIPTION
`claude-bridge` と `claude-code` を利用したOllama連携で発生していた起動時エラーを解決するため、`@openai/codex` (Codex CLI) を利用する方式に切り替えます。

この変更には以下が含まれます:

- **Dockerfileの更新:**
  - `claude-code` と `claude-bridge` のnpmパッケージインストールを削除。
  - `ollama-mcp-bridge` のgit cloneとビルド処理を削除。
  - `@openai/codex` のnpmパッケージインストールを追加。
  - `codex` の推奨環境であるNode.js 22をインストールするように更新。
  - `claude`用のJSON設定ファイル作成ロジックを削除し、`codex`用のTOML設定ファイル (`/root/.codex/config.toml`) を作成するロジックを追加。OllamaとSerena-MCPへの接続設定を記述。

- **docker-compose.ymlの更新:**
  - `claude-bridge`用のポートマッピング (`8080:8080`) と環境変数を削除。
  - 不要になった設定ボリュームを削除し、`claude`用設定パスを`codex`用に更新。

- **start-environment.shの更新:**
  - `claude-bridge`の起動スクリプトを削除。
  - ユーザーへの案内メッセージを `claude` から `codex` に変更。

- **README.mdの更新:**
  - `claude` に関連するすべての記述を `codex` に修正。