### PR TITLE
Fix chemical inaccuracies in calculation templates

### DIFF
--- a/templates/calculate_uv_spectrum.py
+++ b/templates/calculate_uv_spectrum.py
@@ -260,6 +260,12 @@ def main():
     atoms, coords = smiles_to_xyz(args.smiles)
     print(f"原子数: {len(atoms)}")
     
+    print("\n" + "="*60)
+    print("⚠️  警告: 現在の計算は、MMFF力場から生成された初期構造に\n"
+          "   基づいています。より正確な結果を得るには、まず同レベルの\n"
+          "   理論計算で構造最適化を実行することを強く推奨します。")
+    print("="*60)
+
     # PySCF分子作成
     print("\n[2] PySCF分子オブジェクト作成...")
     mol = create_pyscf_mol(atoms, coords, args.basis, args.charge, args.spin)


### PR DESCRIPTION
This commit addresses several chemical inaccuracies and bugs found in the quantum chemistry calculation templates.

The main changes are:

- `calculate_ir_spectrum.py`: Replaced the fake IR intensity calculation, which used random numbers based on frequency ranges, with a scientifically correct implementation using the `pyscf.prop.infrared` module to compute intensities from dipole derivatives.

- `calculate_nmr.py`:
    - Removed the entirely fabricated J-coupling calculation.
    - Replaced the inaccurate chemical shift calculation (which used hard-coded reference values) with a proper method that involves calculating the shielding constants for a TMS reference molecule at the same level of theory.

- `calculate_interaction.py`:
    - Refactored the `calculate_energy` function to be more robust and clear. This fixes a latent bug where BSSE correction for MP2 calculations would fail.
    - Removed misleading, non-functional code for the 'B3LYP-D3' method.

- `calculate_uv_spectrum.py`:
    - Added a prominent warning to inform the user that running the script on default (MMFF) geometries is a methodological shortcut and that QM-optimized geometries are recommended for accurate results.

These changes significantly improve the scientific validity and reliability of the provided calculation templates.