### PR TITLE
feat: Configure Docker for external Ollama connection

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -92,6 +92,7 @@ services:
     # ネットワーク設定
     networks:
       - research-network
+      - default
     
     # セキュリティ設定
     security_opt:
@@ -171,6 +172,8 @@ networks:
       config:
         - subnet: 172.20.0.0/24
           gateway: 172.20.0.1
+  default:
+    external: true
 
 # ボリューム定義
 volumes:

--- a/dockerfile
+++ b/dockerfile
@@ -200,8 +200,8 @@ model = "gpt-oss:20b"
 [model_providers.ollama]
 name = "Ollama"
 # This should point to your Ollama server's API endpoint.
-# The value is taken from the OLLAMA_API_BASE env var in the original dockerfile.
-base_url = "http://host.docker.internal:11434/v1"
+# It uses the service name `ollama` on the shared Docker network.
+base_url = "http://ollama:11434/v1"
 # Ollama does not require an API key.
 api_key_env = ""
 


### PR DESCRIPTION
This change modifies the Docker configuration to allow the `codex` CLI to connect to an Ollama service running in a separate Docker environment.

Initially, an `extra_hosts` entry was added to `docker-compose.yml` to facilitate connection to the host machine.

Based on user feedback, this was revised to a more robust user-defined network approach.

Changes:
- Modified `docker-compose.yml` to connect to an external Docker network named `default`.
- Updated the `codex` configuration in the `dockerfile` to use the service name `ollama` (e.g., `http://ollama:11434/v1`) as the endpoint, enabling direct container-to-container communication over the shared network.