### PR TITLE
serena-mcpとfilesystem-mcpは現在使用されていないため、起動しないように関連するコードをコメントアウトしました。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,8 @@ services:
     # ポートマッピング
     ports:
       - "8888:8888"    # JupyterLab
-      - "9121:9121"    # Serena-MCP SSE
-      - "9122:9122"    # Serena Dashboard
+      # - "9121:9121"    # Serena-MCP SSE
+      # - "9122:9122"    # Serena Dashboard
     
     # ボリュームマウント
     volumes:
@@ -66,7 +66,7 @@ services:
       - ./workspace:/workspace
       
       # 設定ファイル（永続化）
-      - ./config/serena:/root/.serena
+      # - ./config/serena:/root/.serena
       
       # データセット用
       - ./datasets:/datasets

--- a/start-environment.sh
+++ b/start-environment.sh
@@ -35,11 +35,11 @@ fi
 # Codex CLI はユーザーがフォアグラウンドで実行するため、ここでは何も起動しません。
 # 設定は /root/.codex/config.toml で管理されます。
 
-# Serena-MCPの起動
-echo "🎯 Serenaを起動中（MCPサーバーとダッシュボード）..."
-serena start > /workspace/logs/serena.log 2>&1 &
-SERENA_PID=$!
-echo "✅ Serena起動 (PID: $SERENA_PID)"
+# # Serena-MCPの起動
+# echo "🎯 Serenaを起動中（MCPサーバーとダッシュボード）..."
+# serena start > /workspace/logs/serena.log 2>&1 &
+# SERENA_PID=$!
+# echo "✅ Serena起動 (PID: $SERENA_PID)"
 
 # JupyterLabの起動
 echo "📊 JupyterLabを起動中..."


### PR DESCRIPTION
将来的に再利用する可能性を考慮し、コードは削除せずに残しています。

変更点:
- `start-environment.sh`: `serena start`コマンドをコメントアウトしました。
- `docker-compose.yml`: serena-mcpに関連するポートマッピングとボリュームマウントをコメントアウトしました。