### PR TITLE
serena-mcpとfilesystem-mcpは現在使用されていないため、関連するすべての記述を削除しました。

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
       
       # サービス設定
       - JUPYTER_TOKEN=research2025  # 変更推奨
-      - MCP_SERVER_PORT=9121
       
       # Python設定
       - PYTHONPATH=/workspace
@@ -57,16 +56,11 @@ services:
     # ポートマッピング
     ports:
       - "8888:8888"    # JupyterLab
-      # - "9121:9121"    # Serena-MCP SSE
-      # - "9122:9122"    # Serena Dashboard
     
     # ボリュームマウント
     volumes:
       # 作業ディレクトリ（永続化）
       - ./workspace:/workspace
-      
-      # 設定ファイル（永続化）
-      # - ./config/serena:/root/.serena
       
       # データセット用
       - ./datasets:/datasets

--- a/start-environment.sh
+++ b/start-environment.sh
@@ -35,12 +35,6 @@ fi
 # Codex CLI はユーザーがフォアグラウンドで実行するため、ここでは何も起動しません。
 # 設定は /root/.codex/config.toml で管理されます。
 
-# # Serena-MCPの起動
-# echo "🎯 Serenaを起動中（MCPサーバーとダッシュボード）..."
-# serena start > /workspace/logs/serena.log 2>&1 &
-# SERENA_PID=$!
-# echo "✅ Serena起動 (PID: $SERENA_PID)"
-
 # JupyterLabの起動
 echo "📊 JupyterLabを起動中..."
 jupyter lab --ip=0.0.0.0 --port=8888 --no-browser --allow-root \
@@ -58,7 +52,6 @@ echo ""
 echo "📌 アクセス情報:"
 echo "  - JupyterLab: http://localhost:8888"
 echo "  - Token: ${JUPYTER_TOKEN:-research2025}"
-echo "  - Serena Dashboard: http://localhost:9122"
 echo ""
 echo "🎮 RTX 50シリーズ (sm_120) サポート有効"
 echo "🔧 CUDA 12.8 + PyTorch Nightly"


### PR DESCRIPTION
これには、起動スクリプト、docker-composeファイル、およびdockerfileからのすべての関連コードと設定が含まれます。

変更点:
- `start-environment.sh`: `serena start`コマンドと関連するechoを削除しました。
- `docker-compose.yml`: serena-mcpに関連するポートマッピング、ボリューム、環境変数を削除しました。
- `dockerfile`: serena-mcpとfilesystem-mcpに関連するインストール、設定、スクリプト作成などをすべて削除しました。