### PR TITLE
feat: Add dgl library to Dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -91,6 +91,7 @@ RUN pip install --no-cache-dir --no-build-isolation \
     ipython==8.23.0 \
     \
     # 機械学習フレームワーク（PyTorch以外）
+    dgl \
     tensorflow==2.16.1 \
     scikit-learn==1.4.2 \
     xgboost==2.0.3 \


### PR DESCRIPTION
Based on the dependencies in `ms-pred-gcn-eims-cupy.py`, the `dgl` library was missing from the `dockerfile`. This commit adds it to the pip installation list.

Note: The `cupy` dependency is installed as `cupy-cuda12x` to match the CUDA version in the environment.